### PR TITLE
Improve pluralize template handling

### DIFF
--- a/locale.go
+++ b/locale.go
@@ -98,6 +98,14 @@ func RegisterLocale(loc *Locale) {
 	}
 }
 
+// RegisterLocales registers multiple locales in one go.
+func RegisterLocales(locs ...*Locale) {
+	for _, loc := range locs {
+		RegisterLocale(loc)
+	}
+}
+
+// GetLocale returns a pointer to an existing locale object and a boolean whether the locale exists.
 func GetLocale(locale string) (*Locale, bool) {
 	l, ok := locales[locale]
 	return l, ok

--- a/parse_test.go
+++ b/parse_test.go
@@ -7,6 +7,12 @@ import (
 	"testing"
 )
 
+type testCart struct {
+	Name          string
+	Items         []string
+	NumberOfItems int32
+}
+
 func TestParse(t *testing.T) {
 	cases := []struct {
 		locale string
@@ -31,6 +37,34 @@ func TestParse(t *testing.T) {
 			text:   `{{p "Count" (one "{{.Count}} item") (other "{{.Count}} items in Your Cart")}} in Your Cart; {{p "Count2" (one "{{.Count2}} item") (other "{{.Count2}} items in Your Cart")}} in Your Cart`,
 			data:   []interface{}{map[string]int{"Count": 2, "Count2": 1}},
 			want:   "2 items in Your Cart in Your Cart; 1 item in Your Cart",
+		},
+		{
+			locale: "en",
+			text:   `{{p "Cart.Items" (one "1 item") (other "{{len .Cart.Items}} items")}} in your cart; {{p "Cart.NumberOfItems" (one "1 item") (other "{{.Cart.NumberOfItems}} items")}} in your cart.`,
+			data: []interface{}{map[string]interface{}{"Cart": struct {
+				Name          string
+				Items         []string
+				NumberOfItems int32
+			}{Name: "Mr Someone", Items: []string{"Item 1", "Item 2"}, NumberOfItems: 4}}},
+			want: "2 items in your cart; 4 items in your cart.",
+		},
+		{
+			locale: "en",
+			text:   `{{p "Cart2.Items" (one "1 item") (other "{{len .Cart2.Items}} items")}} in your cart; {{p "Cart2.NumberOfItems" (one "1 item") (other "{{.Cart2.NumberOfItems}} items")}} in your cart.`,
+			data:   []interface{}{map[string]interface{}{"Cart2": &testCart{Name: "Test cart", Items: []string{"Item 3", "Item 4", "Item 5"}, NumberOfItems: 6}}},
+			want:   "3 items in your cart; 6 items in your cart.",
+		},
+		{
+			locale: "en",
+			text:   `{{p "." (one "1 item") (other "{{.}} items")}} in your cart.`,
+			data:   []interface{}{4},
+			want:   "4 items in your cart.",
+		},
+		{
+			locale: "en",
+			text:   `{{p "." (one "1 item") (other "{{len .}} items")}} in your cart.`,
+			data:   []interface{}{[]string{"Item 1", "Item 2"}},
+			want:   "2 items in your cart.",
 		},
 		{
 			locale: "en",


### PR DESCRIPTION
This PR makes the usage of `{{p}}` in templates more flexible in what it accepts and how it extracts the thing to pluralize:
- can now pass "." and use {{.}} in the call to use the context object as-is (no need to pass a map, see test)
- can now pass nested map/struct paths via dot notation (see test)
- when it encounters a slice, an array or a channel it now uses the length as the count, making it possible to pass, for example, a `Cart` struct and use `"Cart.Items"` (slice) and `{{len .Cart.Items}}` in the template

All existing tests are still passing and I added more for each of those cases above.
