### PR TITLE
Update moved dependency on cldr package.

### DIFF
--- a/make_resources.go
+++ b/make_resources.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/kr/pretty"
 	i18n "github.com/theplant/cldr"
-	"golang.org/x/text/cldr"
+	"golang.org/x/text/unicode/cldr"
 )
 
 // numbers:


### PR DESCRIPTION
Hi, looks like the make_resources tool got broken by the fact that `golang.org/x/text/cldr` was moved to `golang.org/x/text/unicode/cldr`. Would you mind merging this?